### PR TITLE
[#128] HTML 챕터에서 태그가 파싱되지 않는 버그 외

### DIFF
--- a/src/modules/curriculum/components/Card.tsx
+++ b/src/modules/curriculum/components/Card.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/util/tailwind";
 import Image from "next/image";
 import Link from "next/link";
 import { ReactNode } from "react";
+import { motion } from "framer-motion";
 
 type CardProps = {
     progress: Progress | undefined;
@@ -39,7 +40,7 @@ const MainContainer = ({ imageUrl, path, title, alt, progress, children }: MainC
                 </div>
                 {children}
             </div>
-            {progress && <ProgressBar total={progress.total} solved={progress.solved} />}
+            {progress ? <ProgressBar total={progress.total} solved={progress.solved} /> : <ProgressBarLoading />}
         </div>
     </div>
 );
@@ -56,6 +57,33 @@ const ProgressBar = ({ total, solved }: ProgressBarProps) => (
         <div className="leading-[14px] text-xs">
             <span className="text-point1">{`${solved}문제 완료`}</span>
             <span>{`/ ${total}문제`}</span>
+        </div>
+    </div>
+);
+
+const ProgressBarLoading = () => (
+    <div className="space-y-1.5">
+        <div className="relative overflow-hidden flex rounded bg-primary-50 h-2.5">
+            <motion.div
+                style={{ width: `100%` }}
+                className="shadow-none flex flex-col text-center rounded whitespace-nowrap text-white justify-center bg-secondary-100"
+                animate={{
+                    background: [
+                        "linear-gradient(90deg, #9D9BAE 0%, #CECDD6 50%, #E7E6EB 100%)",
+                        "linear-gradient(90deg, #CECDD6 0%, #E7E6EB 50%, #9D9BAE 100%)",
+                        "linear-gradient(90deg, #E7E6EB 0%, #9D9BAE 50%, #CECDD6 100%)",
+                    ],
+                }}
+                transition={{
+                    repeat: Infinity,
+                    duration: 2,
+                    ease: "linear",
+                }}
+            ></motion.div>
+        </div>
+        <div className="leading-[14px] text-xs">
+            <span className="text-point1">{`-문제 완료`}</span>
+            <span>{`/ -문제`}</span>
         </div>
     </div>
 );

--- a/src/modules/ranking/components/Carousel.tsx
+++ b/src/modules/ranking/components/Carousel.tsx
@@ -115,7 +115,7 @@ type CarouselItemProps = {
 
 const CarouselItem = ({ title, image }: CarouselItemProps) => {
     return (
-        <div className="w-full h-full grid place-items-center bg-white rounded-2xl p-5 drop-shadow">
+        <div className="w-[140px] h-full grid place-items-center bg-white rounded-2xl p-5 drop-shadow">
             <div className="flex flex-col items-center">
                 <div className="grid place-items-center border border-neutral-100 w-[60px] h-[60px] rounded-full bg-white mb-1">
                     <Image src={image} width={60} height={60} alt={`${title} 코스 이미지`} />

--- a/src/modules/ranking/components/RankingList.tsx
+++ b/src/modules/ranking/components/RankingList.tsx
@@ -19,7 +19,7 @@ const RankingList = ({ rankingList }: RankingList) => {
             {myRanking !== -1 && <MyItem user={rankingList[myRanking]} ranking={myRanking + 1} />}
             <div className="h-[calc(100dvh-350px)] w-full rounded-t-2xl overflow-y-auto pt-[46px] bg-white drop-shadow-2xl">
                 <div className="flex flex-col">
-                    {rankingList.map((user, idx) => (
+                    {rankingList.slice(0, 100).map((user, idx) => (
                         <ItemContainer key={user.id}>
                             <Item user={user} ranking={idx + 1} />
                         </ItemContainer>

--- a/src/util/markdown.ts
+++ b/src/util/markdown.ts
@@ -4,8 +4,10 @@ import rehypePrism from "rehype-prism-plus";
 import rehypeStringify from "rehype-stringify";
 
 export const markdownToHtmlString = async (markdownText: string) => {
-    const correctedMarkdown = markdownText.replace(/(\*\*[^*]+\*\*)(\S)/g, "$1 $2").replace(/\\`\\`\\`/g, "```");
-
+    const correctedMarkdown = markdownText
+        .replace(/{{HTMLElement\('(\w+)'\)}}/g, "&lt;$1&gt;")
+        .replace(/(\*\*[^*]+\*\*)(\S)/g, "$1 $2")
+        .replace(/\\`\\`\\`/g, "```");
     const processedContent = await remark().use(remarkRehype).use(rehypePrism).use(rehypeStringify).process(correctedMarkdown);
     return processedContent.toString();
 };


### PR DESCRIPTION
## 작업 내용

* **랭킹에 표시되는 사용자를 상위 100명으로 제한합니다.**
* **캐러샐의 너비가 깨지는 버그를 수정하였습니다.**
* **진척도 fetch loading 중에 skeleton ui 를 표시합니다.**
* **HTMLElement parsing 기능 추가**

## 코멘트

* 캐러샐 너비가 깨지는 버그는 재현이 어려워 완전히 고쳐지지 않았을 수도 있습니다.

## 관련 이슈

* **Close #128**
